### PR TITLE
feat: Use AI brief summaries in episode cards

### DIFF
--- a/src/components/EpisodeCard.astro
+++ b/src/components/EpisodeCard.astro
@@ -11,9 +11,12 @@ interface Props {
   isNew?: boolean;
   loading?: "lazy" | "eager";
   fetchPriority?: "high" | "low" | "auto";
+  brief?: string;
 }
 
-const { title, description, publishedAt, thumbnail, episodeNumber, slug, isNew = false, loading = "lazy", fetchPriority } = Astro.props;
+const { title, description, publishedAt, thumbnail, episodeNumber, slug, isNew = false, loading = "lazy", fetchPriority, brief } = Astro.props;
+
+const displayDescription = brief || description;
 
 const formattedDate = new Date(publishedAt).toLocaleDateString('id-ID', {
   day: 'numeric',
@@ -21,9 +24,9 @@ const formattedDate = new Date(publishedAt).toLocaleDateString('id-ID', {
   year: 'numeric'
 });
 
-const truncatedDescription = description.length > 120 
-  ? description.substring(0, 120) + '...' 
-  : description;
+const truncatedDescription = displayDescription.length > 120
+  ? displayDescription.substring(0, 120) + '...'
+  : displayDescription;
 ---
 
 <a 

--- a/src/components/SearchEpisodes.astro
+++ b/src/components/SearchEpisodes.astro
@@ -6,6 +6,7 @@ const episodes = getEpisodes();
 const searchData = episodes.map((ep, idx) => ({
   title: ep.title,
   description: ep.description,
+  brief: ep.brief,
   slug: ep.slug,
   episodeNumber: ep.episodeNumber,
   thumbnail: ep.thumbnail,
@@ -44,7 +45,7 @@ const searchData = episodes.map((ep, idx) => ({
 
 <div id="episodes-grid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
   {searchData.map((episode, index) => (
-    <EpisodeCard 
+    <EpisodeCard
       title={episode.title}
       description={episode.description}
       publishedAt={episode.publishedAt}
@@ -54,6 +55,7 @@ const searchData = episodes.map((ep, idx) => ({
       isNew={episode.isNew}
       loading={index < 4 ? "eager" : "lazy"}
       fetchPriority={index === 0 ? "high" : undefined}
+      brief={episode.brief}
     />
   ))}
 </div>
@@ -71,7 +73,7 @@ const searchData = episodes.map((ep, idx) => ({
   const searchData = JSON.parse(document.getElementById('episodes-data')?.textContent || '[]');
 
   const fuse = new Fuse(searchData, {
-    keys: ['title', 'description'],
+    keys: ['title', 'description', 'brief'],
     threshold: 0.4,
     includeScore: true
   });
@@ -111,15 +113,17 @@ const searchData = episodes.map((ep, idx) => ({
     noResults.classList.add('hidden');
 
     const truncate = (text, len) => text.length > len ? text.substring(0, len) + '...' : text;
-    
-    grid.innerHTML = episodes.map((ep) => `
-      <a 
+
+    grid.innerHTML = episodes.map((ep) => {
+      const displayDesc = ep.brief || ep.description;
+      return `
+      <a
         href="/episodes/${escapeHtml(ep.slug)}"
         class="group block bg-[#1a1a1a] border border-[#2a2a2a] rounded-xl overflow-hidden hover:border-[#6366f1]/50 transition-all duration-300 hover:shadow-lg hover:shadow-[#6366f1]/10"
       >
         <div class="relative aspect-video overflow-hidden">
-          <img 
-            src="${escapeHtml(ep.thumbnail)}" 
+          <img
+            src="${escapeHtml(ep.thumbnail)}"
             alt="${escapeHtml(ep.title)}"
             class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
             loading="lazy"
@@ -135,11 +139,12 @@ const searchData = episodes.map((ep, idx) => ({
             ${escapeHtml(ep.title)}
           </h3>
           <p class="text-gray-400 text-sm line-clamp-2">
-            ${escapeHtml(truncate(ep.description, 120))}
+            ${escapeHtml(truncate(displayDesc, 120))}
           </p>
         </div>
       </a>
-    `).join('');
+    `;
+    }).join('');
   }
 
   function handleSearch() {

--- a/src/lib/episodes.test.ts
+++ b/src/lib/episodes.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   slugify,
+  getBrief,
   getEpisodes,
   getEpisodeBySlug,
   getEpisodeByVideoId,
@@ -36,6 +37,41 @@ describe('slugify', () => {
   });
 });
 
+describe('getBrief', () => {
+  const existingVideoIds = ['x1jm57leZW0', 'Tkh8-LleLws', 'ZcYNuHirHOA'];
+  const nonExistentVideoId = 'non-existent-video-id-12345';
+
+  it('returns brief string when summary exists', () => {
+    const brief = getBrief(existingVideoIds[0]);
+    expect(brief).toBeDefined();
+    expect(typeof brief).toBe('string');
+    expect(brief?.length).toBeGreaterThan(0);
+  });
+
+  it('returns undefined when summary does not exist', () => {
+    const brief = getBrief(nonExistentVideoId);
+    expect(brief).toBeUndefined();
+  });
+
+  it('returns consistent brief for same videoId', () => {
+    const brief1 = getBrief(existingVideoIds[0]);
+    const brief2 = getBrief(existingVideoIds[0]);
+    expect(brief1).toBe(brief2);
+  });
+
+  it('returns different briefs for different videoIds', () => {
+    const brief1 = getBrief(existingVideoIds[0]);
+    const brief2 = getBrief(existingVideoIds[1]);
+    // Briefs should be different (unless they coincidentally have the same content)
+    expect(brief1).not.toBe(brief2);
+  });
+
+  it('handles empty videoId gracefully', () => {
+    const brief = getBrief('');
+    expect(brief).toBeUndefined();
+  });
+});
+
 describe('getEpisodes', () => {
   it('returns an array', () => {
     const episodes = getEpisodes();
@@ -67,6 +103,30 @@ describe('getEpisodes', () => {
       if (ep.thumbnail.includes('i.ytimg.com')) {
         expect(ep.thumbnail).toMatch(/https:\/\/i\.ytimg\.com\/vi_webp\/.*\/hqdefault\.webp/);
       }
+    }
+  });
+
+  it('populates brief field for episodes with summaries', () => {
+    const episodes = getEpisodes();
+    const episodesWithSummaries = ['x1jm57leZW0', 'Tkh8-LleLws', 'ZcYNuHirHOA'];
+
+    for (const videoId of episodesWithSummaries) {
+      const episode = episodes.find(ep => ep.videoId === videoId);
+      expect(episode).toBeDefined();
+      expect(episode?.brief).toBeDefined();
+      expect(typeof episode?.brief).toBe('string');
+      expect(episode?.brief?.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('does not populate brief for episodes without summaries', () => {
+    const episodes = getEpisodes();
+    // Find an episode that definitely doesn't have a summary
+    const episodeWithoutSummary = episodes.find(ep => !ep.brief);
+
+    // At least one episode should not have a summary (or all have summaries, which is also valid)
+    if (episodeWithoutSummary) {
+      expect(episodeWithoutSummary.brief).toBeUndefined();
     }
   });
 });

--- a/src/lib/episodes.ts
+++ b/src/lib/episodes.ts
@@ -8,6 +8,7 @@ export interface Episode {
   thumbnail: string;
   slug: string;
   episodeNumber: number;
+  brief?: string;
 }
 
 export function slugify(text: string): string {
@@ -17,6 +18,20 @@ export function slugify(text: string): string {
     .replace(/\s+/g, '-')
     .replace(/-+/g, '-')
     .trim();
+}
+
+interface Summary {
+  brief: string;
+  keyPoints: string[];
+}
+
+// Cache summaries at module load time for performance
+const _summariesCache = import.meta.glob('../data/summaries/*.json', { eager: true });
+
+export function getBrief(videoId: string): string | undefined {
+  const key = `../data/summaries/${videoId}.json`;
+  const module = _summariesCache[key] as { default: Summary } | undefined;
+  return module?.default.brief;
 }
 
 let _cache: Episode[] | null = null;
@@ -32,6 +47,7 @@ export function getEpisodes(): Episode[] {
         ? `https://i.ytimg.com/vi_webp/${ep.videoId}/hqdefault.webp`
         : ep.thumbnail,
       episodeNumber: 0, // placeholder, set after sorting
+      brief: getBrief(ep.videoId),
     }))
     .sort((a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime())
     .map((ep, idx, arr) => ({

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -65,7 +65,7 @@ const optimizedLcpImage = await getImage({
       
       <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
         {recentEpisodes.map((episode, index) => (
-          <EpisodeCard 
+          <EpisodeCard
             title={episode.title}
             description={episode.description}
             publishedAt={episode.publishedAt}
@@ -75,6 +75,7 @@ const optimizedLcpImage = await getImage({
             isNew={index < 2}
             loading={index < 3 ? "eager" : "lazy"}
             fetchPriority={index === 0 ? "high" : undefined}
+            brief={episode.brief}
           />
         ))}
       </div>


### PR DESCRIPTION
## Summary
- Add support for displaying AI-generated brief summaries from `data/summaries/{videoId}.json` in episode cards
- Falls back to YouTube descriptions when summaries are unavailable
- Briefs are also included in search indexing for better discoverability

## Screenshot
<img width="756" height="712" alt="CleanShot 2026-01-29 at 09 06 56@2x" src="https://github.com/user-attachments/assets/bb07572f-b1c2-415f-8e7e-d2035450c11d" />

## Changes
- Add `brief?: string` field to Episode interface
- Add `getBrief()` function with cached `import.meta.glob` for performance
- Enrich `getEpisodes()` to populate brief field
- Update EpisodeCard to use `brief || description` for display
- Include brief in SearchEpisodes searchData and search indexing
- Add 7 new unit tests for brief functionality

## Test plan
- [x] All 22 unit tests pass
- [x] Episodes with summaries show brief instead of YouTube description
- [x] Episodes without summaries still show YouTube description
- [x] Search functionality includes brief in search keys
- [x] Code review completed and applied fixes