### PR TITLE
feat: add related episodes feature with auto-tag extraction

### DIFF
--- a/.github/workflows/fetch-playlist.yml
+++ b/.github/workflows/fetch-playlist.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Check for changes
         id: changes
         run: |
-          if git diff --quiet src/data/episodes.json; then
+          if git diff --quiet src/data/episodes.json src/data/tags.json; then
             echo "changed=false" >> $GITHUB_OUTPUT
           else
             echo "changed=true" >> $GITHUB_OUTPUT
@@ -41,6 +41,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add src/data/episodes.json
-          git commit -m "Update episodes from YouTube playlist"
+          git add src/data/episodes.json src/data/tags.json
+          git commit -m "Update episodes and tags from YouTube playlist"
           git push

--- a/scripts/extract-tags.ts
+++ b/scripts/extract-tags.ts
@@ -1,0 +1,139 @@
+/**
+ * Extract tags from episode summaries for related episodes feature
+ *
+ * Usage:
+ *   npx tsx scripts/extract-tags.ts
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+interface Summary {
+  videoId: string;
+  brief: string;
+  keyPoints: string[];
+}
+
+interface TagsData {
+  [videoId: string]: string[];
+}
+
+// Common tech terms to extract as tags
+const TECH_KEYWORDS: Record<string, string[]> = {
+  // Frameworks & Libraries
+  css: ['css', 'tailwind', 'tailwindcss', 'stylesheet', 'styling'],
+  javascript: ['javascript', 'js', 'ecmascript'],
+  typescript: ['typescript', 'ts'],
+  react: ['react', 'reactjs', 'react.js'],
+  vue: ['vue', 'vuejs', 'vue.js'],
+  svelte: ['svelte', 'sveltekit'],
+  angular: ['angular'],
+  nextjs: ['next.js', 'nextjs', 'next js'],
+  astro: ['astro'],
+  node: ['node', 'nodejs', 'node.js'],
+  deno: ['deno'],
+  bun: ['bun'],
+
+  // AI & Tools
+  ai: ['ai', 'artificial intelligence', 'machine learning', 'ml'],
+  'ai-coding': ['agentic', 'copilot', 'cursor', 'claude', 'gemini', 'chatgpt', 'llm'],
+  'dev-tools': ['vscode', 'terminal', 'cli', 'devtools', 'developer tools'],
+
+  // Web Concepts
+  performance: ['performance', 'optimasi', 'optimization', 'speed', 'caching'],
+  accessibility: ['accessibility', 'a11y', 'aksesibilitas'],
+  seo: ['seo', 'search engine'],
+  api: ['api', 'rest', 'graphql', 'endpoint'],
+  testing: ['testing', 'test', 'vitest', 'jest', 'playwright', 'cypress'],
+
+  // UI/UX
+  ui: ['ui', 'user interface', 'komponen', 'component'],
+  ux: ['ux', 'user experience'],
+  animation: ['animation', 'animasi', 'transition', 'motion'],
+  responsive: ['responsive', 'mobile', 'desktop'],
+  design: ['design', 'desain', 'figma', 'design system'],
+
+  // Backend & Infrastructure
+  database: ['database', 'db', 'sql', 'nosql', 'postgres', 'mysql', 'mongodb'],
+  deployment: ['deploy', 'deployment', 'hosting', 'vercel', 'netlify', 'cloudflare'],
+  security: ['security', 'keamanan', 'auth', 'authentication', 'authorization'],
+
+  // Career & Soft Skills
+  career: ['karir', 'career', 'job', 'interview', 'gaji', 'salary'],
+  learning: ['belajar', 'learning', 'tutorial', 'course'],
+  community: ['community', 'komunitas', 'meetup', 'conference'],
+
+  // Specific Topics
+  'web-components': ['web component', 'custom element', 'shadow dom'],
+  pwa: ['pwa', 'progressive web app', 'service worker'],
+  'build-tools': ['bundler', 'webpack', 'vite', 'esbuild', 'rollup'],
+  monorepo: ['monorepo', 'turborepo', 'nx'],
+  'state-management': ['state management', 'redux', 'zustand', 'pinia'],
+};
+
+function extractTags(summary: Summary): string[] {
+  const text = `${summary.brief} ${summary.keyPoints.join(' ')}`.toLowerCase();
+  const foundTags = new Set<string>();
+
+  for (const [tag, keywords] of Object.entries(TECH_KEYWORDS)) {
+    for (const keyword of keywords) {
+      if (text.includes(keyword.toLowerCase())) {
+        foundTags.add(tag);
+        break;
+      }
+    }
+  }
+
+  return Array.from(foundTags).sort();
+}
+
+async function main() {
+  const summariesDir = path.join(__dirname, '../src/data/summaries');
+  const outputPath = path.join(__dirname, '../src/data/tags.json');
+
+  if (!fs.existsSync(summariesDir)) {
+    console.error('Error: summaries directory not found');
+    process.exit(1);
+  }
+
+  const files = fs.readdirSync(summariesDir).filter((f) => f.endsWith('.json'));
+  const tagsData: TagsData = {};
+
+  console.log(`Processing ${files.length} summaries...`);
+
+  for (const file of files) {
+    const filePath = path.join(summariesDir, file);
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const summary: Summary = JSON.parse(content);
+
+    const tags = extractTags(summary);
+    tagsData[summary.videoId] = tags;
+
+    console.log(`  ${summary.videoId}: ${tags.join(', ') || '(no tags)'}`);
+  }
+
+  // Load existing tags to preserve manual edits
+  let existingTags: TagsData = {};
+  if (fs.existsSync(outputPath)) {
+    existingTags = JSON.parse(fs.readFileSync(outputPath, 'utf-8'));
+  }
+
+  // Merge: keep existing manual tags, add new auto-extracted ones
+  const mergedTags: TagsData = { ...existingTags };
+  for (const [videoId, tags] of Object.entries(tagsData)) {
+    if (!mergedTags[videoId]) {
+      mergedTags[videoId] = tags;
+    } else {
+      // Merge unique tags
+      mergedTags[videoId] = Array.from(new Set([...mergedTags[videoId], ...tags])).sort();
+    }
+  }
+
+  fs.writeFileSync(outputPath, JSON.stringify(mergedTags, null, 2));
+  console.log(`\n✓ Saved tags to src/data/tags.json`);
+}
+
+main();

--- a/scripts/fetch-playlist.ts
+++ b/scripts/fetch-playlist.ts
@@ -106,12 +106,33 @@ async function main() {
     const outputPath = new URL('../src/data/episodes.json', import.meta.url);
     const fs = await import('fs');
     
+    // Check for new episodes
+    let existingVideoIds = new Set<string>();
+    try {
+      const existing = JSON.parse(fs.readFileSync(outputPath, 'utf-8')) as Episode[];
+      existingVideoIds = new Set(existing.map(e => e.videoId));
+    } catch {
+      // No existing file
+    }
+    
+    const newEpisodes = episodes.filter(e => !existingVideoIds.has(e.videoId));
+    
     fs.writeFileSync(
       outputPath, 
       JSON.stringify(episodes, null, 2)
     );
     
     console.log(`✓ Saved ${episodes.length} episodes to src/data/episodes.json`);
+    
+    // Auto-run tag extraction if there are new episodes
+    if (newEpisodes.length > 0) {
+      console.log(`\n📌 Found ${newEpisodes.length} new episode(s), extracting tags...`);
+      const { execSync } = await import('child_process');
+      execSync('npx tsx scripts/extract-tags.ts', { 
+        stdio: 'inherit',
+        cwd: new URL('..', import.meta.url).pathname
+      });
+    }
   } catch (error) {
     console.error('Error fetching playlist:', error);
     process.exit(1);

--- a/src/data/tags.json
+++ b/src/data/tags.json
@@ -1,0 +1,79 @@
+{
+  "Qh0ImRYTync": [
+    "ai",
+    "api",
+    "css",
+    "javascript",
+    "responsive",
+    "typescript",
+    "ui"
+  ],
+  "Tkh8-LleLws": [
+    "ai",
+    "ai-coding",
+    "css",
+    "design",
+    "dev-tools",
+    "typescript",
+    "ui"
+  ],
+  "ZcYNuHirHOA": [
+    "ai",
+    "ai-coding",
+    "dev-tools",
+    "ui"
+  ],
+  "_H9EkkzDGTs": [
+    "ai",
+    "database",
+    "security",
+    "ux"
+  ],
+  "aY57UgFCC48": [
+    "ai",
+    "api",
+    "bun",
+    "deployment",
+    "javascript",
+    "learning"
+  ],
+  "lPTtyv8Hzgs": [
+    "ai",
+    "ai-coding",
+    "deployment",
+    "ui"
+  ],
+  "puCZUlxrSpg": [
+    "ai",
+    "api",
+    "bun",
+    "javascript",
+    "learning",
+    "monorepo",
+    "ui"
+  ],
+  "uPiv9JbEOPA": [
+    "ai",
+    "deployment",
+    "design",
+    "dev-tools",
+    "javascript",
+    "ui",
+    "ux"
+  ],
+  "x1jm57leZW0": [
+    "accessibility",
+    "ai",
+    "css",
+    "deployment",
+    "responsive",
+    "typescript"
+  ],
+  "yfgMjKu89u0": [
+    "ai",
+    "api",
+    "build-tools",
+    "javascript",
+    "testing"
+  ]
+}

--- a/src/lib/related.test.ts
+++ b/src/lib/related.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { getEpisodeTags, calculateSimilarity, getRelatedEpisodes } from './related';
+import type { Episode } from './episodes';
+
+describe('getEpisodeTags', () => {
+  it('returns tags for known videoId', () => {
+    const tags = getEpisodeTags('Qh0ImRYTync');
+    expect(Array.isArray(tags)).toBe(true);
+    expect(tags.length).toBeGreaterThan(0);
+  });
+
+  it('returns empty array for unknown videoId', () => {
+    const tags = getEpisodeTags('nonexistent-id');
+    expect(tags).toEqual([]);
+  });
+});
+
+describe('calculateSimilarity', () => {
+  it('returns 0 for episodes with no shared tags', () => {
+    // If one doesn't exist, it has no tags
+    const score = calculateSimilarity('Qh0ImRYTync', 'nonexistent');
+    expect(score).toBe(0);
+  });
+
+  it('returns positive score for episodes with shared tags', () => {
+    // Both of these should have some shared tags (e.g., 'ai', 'css', etc.)
+    const score = calculateSimilarity('Qh0ImRYTync', 'Tkh8-LleLws');
+    expect(score).toBeGreaterThan(0);
+  });
+
+  it('returns same score regardless of order', () => {
+    const score1 = calculateSimilarity('Qh0ImRYTync', 'Tkh8-LleLws');
+    const score2 = calculateSimilarity('Tkh8-LleLws', 'Qh0ImRYTync');
+    expect(score1).toBe(score2);
+  });
+});
+
+describe('getRelatedEpisodes', () => {
+  const mockEpisodes: Episode[] = [
+    {
+      videoId: 'Qh0ImRYTync',
+      title: 'CSS Episode',
+      description: 'Test',
+      publishedAt: '2026-01-01T00:00:00Z',
+      thumbnail: 'https://example.com/thumb.jpg',
+      position: 0,
+      slug: 'css-episode',
+      episodeNumber: 1,
+    },
+    {
+      videoId: 'Tkh8-LleLws',
+      title: 'AI Coding Episode',
+      description: 'Test',
+      publishedAt: '2026-01-02T00:00:00Z',
+      thumbnail: 'https://example.com/thumb.jpg',
+      position: 1,
+      slug: 'ai-coding-episode',
+      episodeNumber: 2,
+    },
+    {
+      videoId: 'ZcYNuHirHOA',
+      title: 'Another Episode',
+      description: 'Test',
+      publishedAt: '2026-01-03T00:00:00Z',
+      thumbnail: 'https://example.com/thumb.jpg',
+      position: 2,
+      slug: 'another-episode',
+      episodeNumber: 3,
+    },
+  ];
+
+  it('excludes current episode from results', () => {
+    const related = getRelatedEpisodes(mockEpisodes[0], mockEpisodes);
+    const hasCurrentEpisode = related.some((ep) => ep.videoId === mockEpisodes[0].videoId);
+    expect(hasCurrentEpisode).toBe(false);
+  });
+
+  it('respects limit parameter', () => {
+    const related = getRelatedEpisodes(mockEpisodes[0], mockEpisodes, 1);
+    expect(related.length).toBeLessThanOrEqual(1);
+  });
+
+  it('returns episodes sorted by similarity', () => {
+    const related = getRelatedEpisodes(mockEpisodes[0], mockEpisodes, 3);
+    // Just verify we get some results and they're valid episodes
+    for (const ep of related) {
+      expect(ep.videoId).toBeDefined();
+      expect(ep.videoId).not.toBe(mockEpisodes[0].videoId);
+    }
+  });
+});

--- a/src/lib/related.ts
+++ b/src/lib/related.ts
@@ -1,0 +1,80 @@
+import type { Episode } from './episodes';
+import tagsData from '../data/tags.json';
+
+const tags: Record<string, string[]> = tagsData;
+
+// Calculate IDF (Inverse Document Frequency) for each tag
+function calculateIDF(): Record<string, number> {
+  const tagCounts: Record<string, number> = {};
+  const totalDocs = Object.keys(tags).length;
+
+  for (const videoTags of Object.values(tags)) {
+    for (const tag of videoTags) {
+      tagCounts[tag] = (tagCounts[tag] || 0) + 1;
+    }
+  }
+
+  const idf: Record<string, number> = {};
+  for (const [tag, count] of Object.entries(tagCounts)) {
+    // Higher IDF = rarer tag = more valuable for similarity
+    idf[tag] = Math.log(totalDocs / count) + 1;
+  }
+
+  return idf;
+}
+
+const idfScores = calculateIDF();
+
+export function getEpisodeTags(videoId: string): string[] {
+  return tags[videoId] || [];
+}
+
+export function calculateSimilarity(videoId1: string, videoId2: string): number {
+  const tags1 = new Set(getEpisodeTags(videoId1));
+  const tags2 = new Set(getEpisodeTags(videoId2));
+
+  if (tags1.size === 0 || tags2.size === 0) {
+    return 0;
+  }
+
+  let score = 0;
+  for (const tag of tags1) {
+    if (tags2.has(tag)) {
+      // Weight shared tags by their IDF (rarer = more valuable)
+      score += idfScores[tag] || 1;
+    }
+  }
+
+  // Normalize by the size of smaller set to favor more specific matches
+  const minSize = Math.min(tags1.size, tags2.size);
+  return score / minSize;
+}
+
+export function getRelatedEpisodes(
+  currentEpisode: Episode,
+  allEpisodes: Episode[],
+  limit = 3
+): Episode[] {
+  const candidates = allEpisodes.filter(
+    (ep) => ep.videoId !== currentEpisode.videoId
+  );
+
+  const scored = candidates.map((episode) => ({
+    episode,
+    score: calculateSimilarity(currentEpisode.videoId, episode.videoId),
+  }));
+
+  // Sort by score descending, then by date (newer first) as tiebreaker
+  scored.sort((a, b) => {
+    if (b.score !== a.score) {
+      return b.score - a.score;
+    }
+    return new Date(b.episode.publishedAt).getTime() - new Date(a.episode.publishedAt).getTime();
+  });
+
+  // Only return episodes with some similarity
+  return scored
+    .filter((s) => s.score > 0)
+    .slice(0, limit)
+    .map((s) => s.episode);
+}

--- a/src/pages/episodes/[slug].astro
+++ b/src/pages/episodes/[slug].astro
@@ -13,6 +13,8 @@ import {
   generateBreadcrumbSchema,
   generatePodcastEpisodeSchema 
 } from '../../lib/seo';
+import { getRelatedEpisodes } from '../../lib/related';
+import EpisodeCard from '../../components/EpisodeCard.astro';
 
 export async function getStaticPaths() {
   const episodes = getEpisodes();
@@ -56,6 +58,8 @@ const siteUrl = Astro.site?.toString().replace(/\/$/, '') || 'https://ngobrolin.
 const videoSchema = generateVideoSchema(episode, summary, transcript, siteUrl);
 const breadcrumbSchema = generateBreadcrumbSchema(episode, siteUrl);
 const podcastSchema = generatePodcastEpisodeSchema(episode, summary, siteUrl);
+
+const relatedEpisodes = getRelatedEpisodes(episode, episodes, 3);
 ---
 
 <Layout 
@@ -114,6 +118,25 @@ const podcastSchema = generatePodcastEpisodeSchema(episode, summary, siteUrl);
           <!-- Transcript -->
           <Transcript videoId={episode.videoId} />
         </div>
+
+        <!-- Related Episodes -->
+        {relatedEpisodes.length > 0 && (
+          <section class="mt-12 pt-8 border-t border-dark-border">
+            <h2 class="text-xl font-bold text-white mb-6">Episode Terkait</h2>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+              {relatedEpisodes.map((ep) => (
+                <EpisodeCard
+                  title={ep.title}
+                  description={ep.description}
+                  publishedAt={ep.publishedAt}
+                  thumbnail={ep.thumbnail}
+                  episodeNumber={ep.episodeNumber}
+                  slug={ep.slug}
+                />
+              ))}
+            </div>
+          </section>
+        )}
 
         <!-- Navigation -->
         <nav class="mt-12 pt-8 border-t border-dark-border">


### PR DESCRIPTION
- Add tag extraction script that parses summaries for tech keywords
- Add related.ts with IDF-weighted similarity scoring
- Display 'Episode Terkait' section on episode pages with 3 related episodes
- Auto-run tag extraction in fetch-playlist.ts when new episodes found
- Update GitHub workflow to commit tags.json alongside episodes.json