### PR TITLE
perf: Defer ClientRouter to improve critical path latency

### DIFF
--- a/e2e/episode.spec.ts
+++ b/e2e/episode.spec.ts
@@ -14,7 +14,7 @@ test.describe('Episode Page', () => {
     const firstEpisode = page.locator('[data-testid="episode-card"]').first();
     await firstEpisode.click();
 
-    await expect(page.locator('h1')).toBeVisible();
+    await expect(page.locator('main h1').first()).toBeVisible();
     await expect(page.locator('lite-youtube')).toBeVisible();
   });
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -44,9 +44,6 @@ const absoluteImage = image.startsWith("http")
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="generator" content={Astro.generator} />
 
-    <!-- View Transitions -->
-    <ClientRouter />
-
     <!-- SEO -->
     <title>{title}</title>
     <meta name="description" content={description} />
@@ -262,6 +259,9 @@ const absoluteImage = image.startsWith("http")
         </div>
       </div>
     </footer>
+
+    <!-- View Transitions (deferred to avoid blocking critical path) -->
+    <ClientRouter />
 
     <!-- Mobile Menu Toggle Script -->
     <script is:inline data-astro-rerun>


### PR DESCRIPTION
## Summary

- Moved `<ClientRouter />` from `<head>` to end of `<body>` to defer loading of the 6.09 KiB JavaScript
- This eliminates ~305ms from the critical rendering path by preventing ClientRouter from blocking initial page render
- Fixed `episode.spec.ts` strict mode violation by using more specific selector for h1 element

<img width="1974" height="528" alt="CleanShot 2026-02-02 at 23 29 22@2x" src="https://github.com/user-attachments/assets/f78bba65-760c-4c65-a375-4c250b671b03" />


## Performance Impact

**Before:**
- Maximum critical path latency: 305 ms
- ClientRouter.astro.js (6.09 KiB) loaded from `<head>` as blocking resource

**After:**
- ClientRouter loaded after initial render (non-blocking)
- Reduced critical path latency for faster initial page load

## Testing

All 28 E2E tests pass, including:
- 9 View Transitions tests (confirms ClientRouter still works correctly)
- 4 Episode Page tests (confirms selector fix works)
- 3 Sitemap tests
- Other navigation and SEO tests

## Test plan

- [x] All E2E tests pass (28/28)
- [x] View transitions still work after navigation
- [x] Build succeeds
- [x] Manual verification in preview server