### PR TITLE
feat: Add Speculation Rules API for faster navigation

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -134,6 +134,21 @@ const jsonLd = {
     <!-- Additional head content -->
     <slot name="head" />
 
+    <!-- Speculation Rules API for prefetch/prerender -->
+    <script type="speculationrules">
+{
+  "prefetch": [{
+    "source": "document",
+    "where": { "href_matches": "/episodes/*" },
+    "eagerness": "eager"
+  }],
+  "prerender": [{
+    "source": "list",
+    "urls": ["/episodes"]
+  }]
+}
+</script>
+
     <!-- Analytics (optional; configured via PUBLIC_UMAMI_* env vars) -->
     <Analytics />
 


### PR DESCRIPTION
## Summary
- Implements Speculation Rules API to prefetch/prerender pages before user clicks
- Adds `<script type="speculationrules">` in Layout.astro head section

## Changes
- **Prefetch**: Episode pages (`/episodes/*`) with `eager` mode
- **Prerender**: Main episodes page (`/episodes`) using list-based speculation

## Benefits
- ✅ Instant navigation — pages loaded before user clicks
- ✅ Better UX — feels like native app
- ✅ No JS framework needed — pure browser API
- ✅ Smart resource usage — browser decides based on connection/memory

## Browser Support
- Chrome 109+/Edge 109+: Full support
- Safari/Firefox: Graceful fallback (normal navigation)

## Testing
- Build passes: 161 pages in 4.81s
- Unit tests: 73 passing
- JSON validated: ✅

Closes #45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Enhanced page loading speed for episode content through optimized resource prefetching and prerendering strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->