### PR TITLE
Add fallback to summary for podcast episode descriptions

### DIFF
--- a/src/lib/podcast.ts
+++ b/src/lib/podcast.ts
@@ -29,6 +29,7 @@ export interface PodcastMetadata {
 interface RawEpisode {
   videoId: string;
   title: string;
+  summary?: string;
   description: string;
   publishedAt: string;
   thumbnail: string;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Podcast episode descriptions now prefer an episode's summary when available, providing more relevant information to listeners.
  * Episode descriptions consistently include the standard appended note, ensuring uniform formatting across episodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->