### PR TITLE
fix: add required VideoObject fields and fix uploadDate format

### DIFF
--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -60,7 +60,7 @@ export function generateVideoSchema(
     name: episode.title,
     description: summary?.brief || episode.description,
     thumbnailUrl: episode.thumbnail,
-    uploadDate: episode.publishedAt.split('T')[0],
+    uploadDate: episode.publishedAt,
     embedUrl: `https://www.youtube.com/embed/${episode.videoId}`,
     contentUrl: `https://www.youtube.com/watch?v=${episode.videoId}`,
     publisher: {
@@ -130,7 +130,12 @@ export function generatePodcastEpisodeSchema(
     url: `${siteUrl}/episodes/${episode.slug}`,
     associatedMedia: {
       '@type': 'VideoObject',
-      embedUrl: `https://www.youtube.com/embed/${episode.videoId}`
+      name: episode.title,
+      description: summary?.brief || episode.description,
+      thumbnailUrl: episode.thumbnail,
+      uploadDate: episode.publishedAt,
+      embedUrl: `https://www.youtube.com/embed/${episode.videoId}`,
+      contentUrl: `https://www.youtube.com/watch?v=${episode.videoId}`
     },
     partOfSeries: {
       '@type': 'PodcastSeries',


### PR DESCRIPTION
## Summary
Fix Google Search Console schema.org errors on episode pages by adding required VideoObject fields and correcting the uploadDate format.

## Changes
- **generatePodcastEpisodeSchema**: Add missing required fields (`name`, `thumbnailUrl`, `uploadDate`, `description`) to `VideoObject` in `associatedMedia`
- **generateVideoSchema**: Fix `uploadDate` to use full ISO 8601 format with timezone (e.g., `2026-01-27T22:28:08Z`) instead of date-only format (`YYYY-MM-DD`)

## Fixes
Resolves the following Google Search Console errors:
- ✅ Missing field "name" in VideoObject
- ✅ Missing field "thumbnailUrl" in VideoObject
- ✅ Missing field "uploadDate" in VideoObject
- ✅ Missing field "description" in VideoObject
- ✅ Datetime property "uploadDate" is missing a timezone
- ✅ Invalid datetime value for "uploadDate"

## Test plan
- [x] All 85 tests pass
- [x] Built HTML verified to contain all required VideoObject fields
- [x] Both standalone VideoObject and VideoObject inside PodcastEpisode are complete
- [ ] After deployment, verify Google Search Console errors clear on re-crawl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Video metadata timestamps now include complete date and time information instead of date-only format
  * Podcast episode metadata expanded with enhanced descriptive fields and additional content references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->