### PR TITLE
feat: add OpenAI diarization support for transcriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,35 @@ console.log('fullText length:', t.fullText.length);
 - Per-episode errors are caught and logged — processing continues to the next episode on failure
 - The script checks all requirements (API key, yt-dlp, ffmpeg, ffprobe) before starting and reports any missing ones
 
+#### Experimental diarization
+
+Use the separate diarization script when you want speaker labels in transcript segments. This path is isolated from the stable OpenAI-compatible script because it depends on OpenAI's experimental diarization response format.
+
+```bash
+# Transcribe 3 missing episodes with diarization
+OPENAI_API_KEY=sk-... npm run transcribe:openai:diarize -- \
+  --missing --limit 3 --browser chrome \
+  --known-speaker "Alice=refs/alice.wav" \
+  --known-speaker "Bob=refs/bob.wav" \
+  --response-format diarized_json
+```
+
+| Flag | Description | Default |
+| --- | --- | --- |
+| `--model <name>` | Diarization model name | `gpt-4o-transcribe-diarize` |
+| `--base-url <url>` | Custom OpenAI endpoint base URL | OpenAI default |
+| `--browser <name>` | Browser for cookies (chrome, brave, firefox, etc.) | `brave` |
+| `--limit <number>` | Max number of episodes to process | None (all) |
+| `--known-speaker "Name=path"` | Repeatable speaker reference mapping | None |
+| `--response-format diarized_json` | Required diarized response format | `diarized_json` |
+| `--missing` | Process episodes without transcripts | - |
+| `--all` | Process all episodes | - |
+
+Notes:
+
+- The saved transcript schema stays the same and adds `speaker` only on diarized segments.
+- This script currently requires `gpt-4o-transcribe-diarize`. `gpt-4o-mini-transcribe` is not supported here because it does not return timestamped segments needed by the existing transcript JSON format.
+
 ---
 
 ### Filtering Non-Conversation Elements

--- a/docs/plans/2026-03-06-openai-diarize-design.md
+++ b/docs/plans/2026-03-06-openai-diarize-design.md
@@ -1,0 +1,118 @@
+# OpenAI Diarize Script Design
+
+**Date:** 2026-03-06
+
+**Goal:** Add a separate experimental OpenAI diarization script while extracting shared transcription helpers used by all transcription entrypoints.
+
+## Context
+
+The repository already has:
+
+- `scripts/transcribe.js` for local `whisper-cli`
+- `scripts/transcribe-openai.js` for standard OpenAI-compatible transcription
+
+The new requirement is to keep diarization isolated in a new script so experimental OpenAI-only behavior does not reduce compatibility in the stable script.
+
+## Decisions
+
+### 1. Separate diarization entrypoint
+
+Create `scripts/transcribe-openai-diarize.js` instead of extending `scripts/transcribe-openai.js`.
+
+Rationale:
+
+- Keeps the current OpenAI/Groq flow stable
+- Allows the new script to evolve independently if the experimental API changes
+- Avoids CLI ambiguity around when diarization should be enabled
+
+### 2. Shared helpers across all transcription scripts
+
+Create a shared helper module used by:
+
+- `scripts/transcribe.js`
+- `scripts/transcribe-openai.js`
+- `scripts/transcribe-openai-diarize.js`
+
+Shared utilities should include:
+
+- common paths and temp directories
+- executable lookup
+- episode loading
+- transcript discovery
+- YouTube audio download
+- transcript filtering for non-conversation segments
+- transcript file writing
+- temp file cleanup helpers
+
+Provider-specific logic should remain local to each script.
+
+### 3. Stable transcript output schema
+
+All scripts should continue writing the same transcript object shape:
+
+```json
+{
+  "videoId": "string",
+  "language": "id",
+  "generatedAt": "ISO-8601 timestamp",
+  "segments": [
+    {
+      "start": 0,
+      "end": 1.2,
+      "text": "..."
+    }
+  ],
+  "fullText": "..."
+}
+```
+
+For diarized transcripts, segments may include an additional `speaker` property:
+
+```json
+{
+  "start": 0,
+  "end": 1.2,
+  "text": "...",
+  "speaker": "Alice"
+}
+```
+
+This keeps downstream transcript consumers compatible while exposing speaker data when available.
+
+### 4. CLI behavior for the new script
+
+`scripts/transcribe-openai-diarize.js` should support:
+
+- existing episode selection flags: `--all`, `--missing`, explicit `videoId`
+- existing utility flags: `--limit`, `--browser`, `--base-url`
+- diarization-specific flags:
+  - `--model`
+  - repeated `--known-speaker "Name=path"`
+  - optional `--response-format diarized_json`
+
+Default model should be `gpt-4o-transcribe-diarize`.
+
+If a non-diarization model is used, the script may still submit the request, but speaker labels should only be written when the API returns diarized segments.
+
+### 5. Keep chunking local to OpenAI scripts
+
+Chunking, file size checks, and OpenAI request retry behavior should stay in the OpenAI-based scripts rather than moving into shared utilities.
+
+Rationale:
+
+- `scripts/transcribe.js` does not use the same API constraints
+- the experimental diarization flow may need to diverge later
+- shared code should stay small and provider-neutral
+
+## Testing Strategy
+
+Add unit tests for the new pure helper functions instead of relying on live API calls.
+
+Planned coverage:
+
+- parsing repeated `--known-speaker` values
+- converting known speaker audio files into data URLs
+- normalizing diarized responses into the shared transcript schema
+- validating shared transcript save/filter behavior where practical
+
+Live verification with the OpenAI diarization API is out of scope for this environment because networked end-to-end validation is unavailable.

--- a/docs/plans/2026-03-06-openai-diarize.md
+++ b/docs/plans/2026-03-06-openai-diarize.md
@@ -1,0 +1,122 @@
+# OpenAI Diarize Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a separate experimental OpenAI diarization script and refactor shared transcription helpers for all existing transcription entrypoints.
+
+**Architecture:** Shared provider-neutral utilities will move into `scripts/lib/transcribe-common.js`, while each transcription script keeps its provider-specific request and normalization logic. The new diarization script will normalize speaker-labeled segments into the existing transcript schema with an optional `speaker` field.
+
+**Tech Stack:** Node.js, ES modules, OpenAI Node SDK, Vitest, existing `yt-dlp`/`ffmpeg` shell tooling
+
+---
+
+### Task 1: Extract shared transcription utilities
+
+**Files:**
+- Create: `scripts/lib/transcribe-common.js`
+- Modify: `scripts/transcribe.js`
+- Modify: `scripts/transcribe-openai.js`
+- Test: `scripts/lib/transcribe-common.test.js`
+
+**Step 1: Write the failing test**
+
+Create unit tests for extracted pure helpers such as non-conversation filtering and transcript assembly/saving inputs.
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm run test:unit -- scripts/lib/transcribe-common.test.js`
+Expected: FAIL because the shared module does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Create `scripts/lib/transcribe-common.js` with shared constants and provider-neutral helpers, then update `scripts/transcribe.js` and `scripts/transcribe-openai.js` to import them.
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm run test:unit -- scripts/lib/transcribe-common.test.js`
+Expected: PASS
+
+### Task 2: Add diarization parsing and normalization helpers
+
+**Files:**
+- Create: `scripts/lib/transcribe-openai-diarize.js`
+- Test: `scripts/lib/transcribe-openai-diarize.test.js`
+
+**Step 1: Write the failing test**
+
+Add tests covering:
+
+- `parseKnownSpeakers`
+- `fileToDataUrl`
+- diarized response normalization into `{ start, end, text, speaker }`
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm run test:unit -- scripts/lib/transcribe-openai-diarize.test.js`
+Expected: FAIL because the module does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Create provider-specific diarization helpers that parse CLI inputs and normalize OpenAI diarized responses.
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm run test:unit -- scripts/lib/transcribe-openai-diarize.test.js`
+Expected: PASS
+
+### Task 3: Add the new diarization script entrypoint
+
+**Files:**
+- Create: `scripts/transcribe-openai-diarize.js`
+- Modify: `package.json`
+- Test: `scripts/transcribe-openai-diarize.test.js`
+
+**Step 1: Write the failing test**
+
+Add tests for argument parsing and transcript normalization decisions that the new script relies on.
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm run test:unit -- scripts/transcribe-openai-diarize.test.js`
+Expected: FAIL because the entrypoint helpers are not wired yet.
+
+**Step 3: Write minimal implementation**
+
+Create the new entrypoint with:
+
+- OpenAI client setup
+- CLI parsing
+- known speaker reference handling
+- chunked transcription flow
+- transcript save path reusing shared helpers
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm run test:unit -- scripts/transcribe-openai-diarize.test.js`
+Expected: PASS
+
+### Task 4: Verify existing scripts still work after refactor
+
+**Files:**
+- Modify: `README.md` (only if usage docs need updating)
+
+**Step 1: Run targeted unit tests**
+
+Run: `npm run test:unit -- scripts/lib/transcribe-common.test.js scripts/lib/transcribe-openai-diarize.test.js scripts/transcribe-openai-diarize.test.js`
+Expected: PASS
+
+**Step 2: Run syntax smoke checks**
+
+Run:
+
+```bash
+node --check scripts/transcribe.js
+node --check scripts/transcribe-openai.js
+node --check scripts/transcribe-openai-diarize.js
+```
+
+Expected: all commands succeed without syntax errors
+
+**Step 3: Optionally update usage docs**
+
+If the new script should be discoverable immediately, add a matching npm script and short usage example to `README.md`.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "transcribe": "node scripts/transcribe.js",
-    "transcribe:openai": "node scripts/transcribe-openai.js"
+    "transcribe:openai": "node scripts/transcribe-openai.js",
+    "transcribe:openai:diarize": "node scripts/transcribe-openai-diarize.js"
   },
   "dependencies": {
     "@astrojs/rss": "^4.0.15",

--- a/scripts/lib/transcribe-common.js
+++ b/scripts/lib/transcribe-common.js
@@ -1,0 +1,178 @@
+import { execSync, spawnSync } from "child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export const ROOT_DIR = join(__dirname, "../..");
+export const TRANSCRIPTS_DIR = join(ROOT_DIR, "src/data/transcripts");
+export const EPISODES_FILE = join(ROOT_DIR, "src/data/episodes.json");
+export const TEMP_DIR = join(ROOT_DIR, ".tmp-audio");
+
+export const ALLOWED_BROWSERS = [
+  "brave",
+  "chrome",
+  "firefox",
+  "safari",
+  "edge",
+  "chromium",
+  "opera",
+  "vivaldi",
+];
+
+const NON_CONVERSATION_PATTERNS = [
+  /^\[musik\]$/i,
+  /^\[music\]$/i,
+  /^\[musik intro\]$/i,
+  /^\[suara musik\]$/i,
+  /^\[dialog musik\]$/i,
+  /^\[tinggalow\]$/i,
+  /^\[ting tong\]$/i,
+  /^\[tinggil\]$/i,
+  /^\[telolet\]$/i,
+  /^\[ringtone\]$/i,
+  /^\[drinton\]$/i,
+  /^\[suara panggilan\]$/i,
+  /^\[suara nafas\]$/i,
+  /^\[tertawa\]$/i,
+  /^\[ketawa\]$/i,
+  /^\[gelak\]$/i,
+  /^\[tepuk tangan\]$/i,
+  /^\[sampai jumpa di video selanjutnya\]$/i,
+  /^\[tekan like dan subscribe\]$/i,
+];
+
+export function findExecutable(name, fallback) {
+  try {
+    return execSync(`which ${name}`, { encoding: "utf-8" }).trim();
+  } catch {
+    if (fallback && existsSync(fallback)) {
+      return fallback;
+    }
+    throw new Error(
+      `Could not find ${name}. Ensure it's installed or check the path: ${fallback}`
+    );
+  }
+}
+
+export function ensureDirectory(dirPath) {
+  if (!existsSync(dirPath)) {
+    mkdirSync(dirPath, { recursive: true });
+  }
+}
+
+export function isNonConversation(text) {
+  return NON_CONVERSATION_PATTERNS.some((pattern) => pattern.test(text.trim()));
+}
+
+export function filterNonConversation(segments) {
+  const filtered = segments.filter((segment) => !isNonConversation(segment.text));
+  const removedCount = segments.length - filtered.length;
+  if (removedCount > 0) {
+    console.log(`  Filtered out ${removedCount} non-conversation segment(s)`);
+  }
+  return filtered;
+}
+
+export function buildTranscript(videoId, segments, options = {}) {
+  const {
+    generatedAt = new Date().toISOString(),
+    language = "id",
+  } = options;
+
+  return {
+    videoId,
+    language,
+    generatedAt,
+    segments,
+    fullText: segments.map((segment) => segment.text).join(" "),
+  };
+}
+
+export function saveTranscript(videoId, segments, options = {}) {
+  ensureDirectory(options.transcriptsDir ?? TRANSCRIPTS_DIR);
+
+  const transcript = buildTranscript(videoId, segments, options);
+  const outputPath = join(
+    options.transcriptsDir ?? TRANSCRIPTS_DIR,
+    `${videoId}.json`
+  );
+
+  writeFileSync(outputPath, JSON.stringify(transcript, null, 2));
+  console.log(`  Saved transcript: ${outputPath}`);
+
+  return transcript;
+}
+
+export function getEpisodes() {
+  return JSON.parse(readFileSync(EPISODES_FILE, "utf-8"));
+}
+
+export function getExistingTranscripts() {
+  ensureDirectory(TRANSCRIPTS_DIR);
+
+  const files = execSync(`ls "${TRANSCRIPTS_DIR}"`, {
+    encoding: "utf-8",
+  }).trim();
+
+  if (!files) {
+    return new Set();
+  }
+
+  return new Set(files.split("\n").map((file) => file.replace(".json", "")));
+}
+
+export function downloadAudio(
+  videoId,
+  {
+    audioFormat,
+    browser = "brave",
+    outputExtension = audioFormat,
+    ytDlpPath,
+  }
+) {
+  ensureDirectory(TEMP_DIR);
+
+  const outputPath = join(TEMP_DIR, `${videoId}.${outputExtension}`);
+
+  if (existsSync(outputPath)) {
+    console.log(`  Audio already exists: ${outputPath}`);
+    return outputPath;
+  }
+
+  console.log(`  Downloading audio for ${videoId}...`);
+
+  spawnSync(
+    ytDlpPath,
+    [
+      "-x",
+      "--audio-format",
+      audioFormat,
+      "--audio-quality",
+      "0",
+      "--cookies-from-browser",
+      browser,
+      "-o",
+      outputPath,
+      `https://www.youtube.com/watch?v=${videoId}`,
+    ],
+    { stdio: "inherit" }
+  );
+
+  return outputPath;
+}
+
+export function cleanupFiles(files) {
+  for (const file of files) {
+    if (existsSync(file)) {
+      unlinkSync(file);
+    }
+  }
+}

--- a/scripts/lib/transcribe-common.test.js
+++ b/scripts/lib/transcribe-common.test.js
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { buildTranscript, filterNonConversation } from "./transcribe-common.js";
+
+describe("filterNonConversation", () => {
+  it("removes configured non-conversation markers and preserves real speech", () => {
+    const segments = [
+      { start: 0, end: 1, text: "[Musik]" },
+      { start: 1, end: 2, text: "Halo semuanya" },
+      { start: 2, end: 3, text: "[tepuk tangan]" },
+      { start: 3, end: 4, text: "Kita mulai ya" },
+    ];
+
+    expect(filterNonConversation(segments)).toEqual([
+      { start: 1, end: 2, text: "Halo semuanya" },
+      { start: 3, end: 4, text: "Kita mulai ya" },
+    ]);
+  });
+});
+
+describe("buildTranscript", () => {
+  it("builds the saved transcript shape and preserves optional speaker labels", () => {
+    const transcript = buildTranscript("video-123", [
+      { start: 0, end: 1.5, text: "Halo", speaker: "Alice" },
+      { start: 1.5, end: 3, text: "Hai", speaker: "Bob" },
+    ], {
+      generatedAt: "2026-03-06T12:00:00.000Z",
+    });
+
+    expect(transcript).toEqual({
+      videoId: "video-123",
+      language: "id",
+      generatedAt: "2026-03-06T12:00:00.000Z",
+      segments: [
+        { start: 0, end: 1.5, text: "Halo", speaker: "Alice" },
+        { start: 1.5, end: 3, text: "Hai", speaker: "Bob" },
+      ],
+      fullText: "Halo Hai",
+    });
+  });
+});

--- a/scripts/lib/transcribe-openai-diarize.js
+++ b/scripts/lib/transcribe-openai-diarize.js
@@ -1,0 +1,63 @@
+import { readFileSync } from "fs";
+import { extname } from "path";
+
+const AUDIO_MIME_TYPES = {
+  ".flac": "audio/flac",
+  ".m4a": "audio/mp4",
+  ".mp3": "audio/mpeg",
+  ".mp4": "audio/mp4",
+  ".mpeg": "audio/mpeg",
+  ".mpga": "audio/mpeg",
+  ".ogg": "audio/ogg",
+  ".wav": "audio/wav",
+  ".webm": "audio/webm",
+};
+
+export function parseKnownSpeakers(values = []) {
+  return values.map((value) => {
+    const separatorIndex = value.indexOf("=");
+
+    if (separatorIndex < 1 || separatorIndex === value.length - 1) {
+      throw new Error('--known-speaker must use the format "Name=path"');
+    }
+
+    const name = value.slice(0, separatorIndex).trim();
+    const path = value.slice(separatorIndex + 1).trim();
+
+    if (!name || !path) {
+      throw new Error('--known-speaker must use the format "Name=path"');
+    }
+
+    return { name, path };
+  });
+}
+
+export function fileToDataUrl(filePath) {
+  const extension = extname(filePath).toLowerCase();
+  const mimeType = AUDIO_MIME_TYPES[extension];
+
+  if (!mimeType) {
+    throw new Error(`Unsupported speaker reference format: ${extension || filePath}`);
+  }
+
+  const base64 = readFileSync(filePath).toString("base64");
+  return `data:${mimeType};base64,${base64}`;
+}
+
+export function buildKnownSpeakerReferences(knownSpeakers = []) {
+  return {
+    known_speaker_names: knownSpeakers.map((speaker) => speaker.name),
+    known_speaker_references: knownSpeakers.map((speaker) =>
+      fileToDataUrl(speaker.path)
+    ),
+  };
+}
+
+export function normalizeDiarizedSegments(response, offsetSeconds = 0) {
+  return (response.segments ?? []).map((segment) => ({
+    start: segment.start + offsetSeconds,
+    end: segment.end + offsetSeconds,
+    text: segment.text.trim(),
+    speaker: segment.speaker,
+  }));
+}

--- a/scripts/lib/transcribe-openai-diarize.test.js
+++ b/scripts/lib/transcribe-openai-diarize.test.js
@@ -1,0 +1,78 @@
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  fileToDataUrl,
+  normalizeDiarizedSegments,
+  parseKnownSpeakers,
+} from "./transcribe-openai-diarize.js";
+
+const tempDirs = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+describe("parseKnownSpeakers", () => {
+  it("parses repeated speaker arguments into matching names and paths", () => {
+    expect(parseKnownSpeakers([
+      "Alice=refs/alice.wav",
+      "Bob=refs/bob.wav",
+    ])).toEqual([
+      { name: "Alice", path: "refs/alice.wav" },
+      { name: "Bob", path: "refs/bob.wav" },
+    ]);
+  });
+
+  it("throws when a speaker reference is malformed", () => {
+    expect(() => parseKnownSpeakers(["Alice"])).toThrow(
+      '--known-speaker must use the format "Name=path"'
+    );
+  });
+});
+
+describe("fileToDataUrl", () => {
+  it("encodes audio files as data URLs using the file extension mime type", () => {
+    const dir = mkdtempSync(join(tmpdir(), "diarize-"));
+    tempDirs.push(dir);
+
+    const filePath = join(dir, "alice.wav");
+    writeFileSync(filePath, "hello");
+
+    expect(fileToDataUrl(filePath)).toBe("data:audio/wav;base64,aGVsbG8=");
+  });
+});
+
+describe("normalizeDiarizedSegments", () => {
+  it("maps diarized response segments into the saved transcript format", () => {
+    const response = {
+      segments: [
+        {
+          id: "seg_1",
+          start: 0.25,
+          end: 1.5,
+          speaker: "Alice",
+          text: " Halo ",
+          type: "transcript.text.segment",
+        },
+        {
+          id: "seg_2",
+          start: 1.5,
+          end: 3,
+          speaker: "Bob",
+          text: "Hai",
+          type: "transcript.text.segment",
+        },
+      ],
+    };
+
+    expect(normalizeDiarizedSegments(response, 10)).toEqual([
+      { start: 10.25, end: 11.5, text: "Halo", speaker: "Alice" },
+      { start: 11.5, end: 13, text: "Hai", speaker: "Bob" },
+    ]);
+  });
+});

--- a/scripts/transcribe-openai-diarize.js
+++ b/scripts/transcribe-openai-diarize.js
@@ -1,0 +1,393 @@
+#!/usr/bin/env node
+
+import { execSync, spawnSync } from "child_process";
+import {
+  createReadStream,
+  existsSync,
+  statSync,
+} from "fs";
+import { join } from "path";
+import { pathToFileURL } from "url";
+import OpenAI from "openai";
+import {
+  ALLOWED_BROWSERS,
+  TEMP_DIR,
+  cleanupFiles,
+  downloadAudio,
+  filterNonConversation,
+  findExecutable,
+  getEpisodes,
+  getExistingTranscripts,
+  saveTranscript,
+} from "./lib/transcribe-common.js";
+import {
+  buildKnownSpeakerReferences,
+  normalizeDiarizedSegments,
+  parseKnownSpeakers,
+} from "./lib/transcribe-openai-diarize.js";
+
+const YT_DLP_FALLBACK = "/Users/riza/.nix-profile/bin/yt-dlp";
+const YT_DLP = findExecutable("yt-dlp", YT_DLP_FALLBACK);
+
+const MAX_FILE_SIZE = 24 * 1024 * 1024;
+const DEFAULT_MODEL = "gpt-4o-transcribe-diarize";
+const REQUIRED_RESPONSE_FORMAT = "diarized_json";
+const MAX_RETRIES = 3;
+
+export function parseArgs(rawArgs) {
+  const parsed = {
+    baseURL: undefined,
+    browser: "brave",
+    knownSpeakerArgs: [],
+    limit: null,
+    model: DEFAULT_MODEL,
+    responseFormat: REQUIRED_RESPONSE_FORMAT,
+    targets: [],
+  };
+
+  for (let index = 0; index < rawArgs.length; index++) {
+    const arg = rawArgs[index];
+
+    if (arg === "--base-url") {
+      parsed.baseURL = requireValue(rawArgs, index, "--base-url");
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--model") {
+      parsed.model = requireValue(rawArgs, index, "--model");
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--browser") {
+      const browser = requireValue(rawArgs, index, "--browser");
+      if (!ALLOWED_BROWSERS.includes(browser)) {
+        throw new Error(`--browser must be one of: ${ALLOWED_BROWSERS.join(", ")}`);
+      }
+      parsed.browser = browser;
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--limit") {
+      const value = requireValue(rawArgs, index, "--limit");
+      const limit = Number.parseInt(value, 10);
+      if (Number.isNaN(limit) || limit < 1) {
+        throw new Error("--limit must be a positive integer");
+      }
+      parsed.limit = limit;
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--known-speaker") {
+      parsed.knownSpeakerArgs.push(requireValue(rawArgs, index, "--known-speaker"));
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--response-format") {
+      parsed.responseFormat = requireValue(rawArgs, index, "--response-format");
+      index += 1;
+      continue;
+    }
+
+    parsed.targets.push(arg);
+  }
+
+  return parsed;
+}
+
+function requireValue(args, index, flagName) {
+  const value = args[index + 1];
+  if (!value || value.startsWith("-")) {
+    throw new Error(`${flagName} requires a value`);
+  }
+  return value;
+}
+
+function checkRequirements(apiKey) {
+  const missing = [];
+
+  if (!apiKey) {
+    missing.push("OPENAI_API_KEY environment variable is not set");
+  }
+
+  for (const tool of ["yt-dlp", "ffmpeg", "ffprobe"]) {
+    try {
+      execSync(`which ${tool}`, { encoding: "utf-8", stdio: "pipe" });
+    } catch {
+      const hint = tool === "yt-dlp" ? "brew install yt-dlp" : "brew install ffmpeg";
+      missing.push(`${tool} not found in PATH - install via: ${hint}`);
+    }
+  }
+
+  if (missing.length > 0) {
+    console.error("Missing requirements:");
+    for (const item of missing) {
+      console.error(`  x ${item}`);
+    }
+    process.exit(1);
+  }
+
+  console.log("Requirements: OK OPENAI_API_KEY, yt-dlp, ffmpeg, ffprobe");
+}
+
+function validateConfiguration(options) {
+  if (options.responseFormat !== REQUIRED_RESPONSE_FORMAT) {
+    throw new Error(
+      `scripts/transcribe-openai-diarize.js requires --response-format ${REQUIRED_RESPONSE_FORMAT}`
+    );
+  }
+
+  if (options.model !== DEFAULT_MODEL) {
+    throw new Error(
+      `scripts/transcribe-openai-diarize.js currently requires --model ${DEFAULT_MODEL} because non-diarized models do not return timestamped segments`
+    );
+  }
+}
+
+function getAudioDuration(audioPath) {
+  const result = spawnSync(
+    "ffprobe",
+    ["-v", "quiet", "-print_format", "json", "-show_format", audioPath],
+    { encoding: "utf-8" }
+  );
+  const info = JSON.parse(result.stdout);
+  return Number.parseFloat(info.format.duration);
+}
+
+function splitAudio(audioPath, videoId, chunkDuration) {
+  const chunkBase = join(TEMP_DIR, `${videoId}_chunk`);
+
+  spawnSync(
+    "ffmpeg",
+    [
+      "-i",
+      audioPath,
+      "-f",
+      "segment",
+      "-segment_time",
+      String(chunkDuration),
+      "-c",
+      "copy",
+      `${chunkBase}_%03d.mp3`,
+    ],
+    { stdio: "inherit" }
+  );
+
+  const chunks = [];
+  let index = 0;
+  while (true) {
+    const chunkPath = `${chunkBase}_${String(index).padStart(3, "0")}.mp3`;
+    if (!existsSync(chunkPath)) {
+      break;
+    }
+    chunks.push(chunkPath);
+    index += 1;
+  }
+
+  return chunks;
+}
+
+function parseWaitTime(errorMessage) {
+  const minuteMatch = errorMessage.match(/try again in (\d+)m(\d+\.?\d*)s/);
+  if (minuteMatch) {
+    return Number.parseInt(minuteMatch[1], 10) * 60 + Number.parseFloat(minuteMatch[2]);
+  }
+
+  const secondMatch = errorMessage.match(/try again in (\d+\.?\d*)s/);
+  if (secondMatch) {
+    return Number.parseFloat(secondMatch[1]);
+  }
+
+  return 60;
+}
+
+async function withRetry(fn) {
+  let lastError;
+
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+
+      if (error.status !== 429 && error.statusCode !== 429) {
+        throw error;
+      }
+
+      const waitTime = parseWaitTime(error.message);
+      if (attempt < MAX_RETRIES) {
+        console.log(
+          `  Rate limited. Waiting ${waitTime.toFixed(1)}s before retry ${attempt}/${MAX_RETRIES}...`
+        );
+        await new Promise((resolve) => setTimeout(resolve, waitTime * 1000));
+      } else {
+        console.log(`  Rate limited. Max retries (${MAX_RETRIES}) reached.`);
+      }
+    }
+  }
+
+  throw lastError;
+}
+
+async function callDiarizedTranscriptionApi(
+  openai,
+  model,
+  filePath,
+  knownSpeakerReferences,
+  offsetSeconds = 0
+) {
+  const response = await openai.audio.transcriptions.create({
+    file: createReadStream(filePath),
+    model,
+    language: "id",
+    response_format: REQUIRED_RESPONSE_FORMAT,
+    chunking_strategy: "auto",
+    ...(knownSpeakerReferences.known_speaker_names.length > 0
+      ? knownSpeakerReferences
+      : {}),
+  });
+
+  return normalizeDiarizedSegments(response, offsetSeconds);
+}
+
+async function transcribe(audioPath, videoId, openai, options) {
+  console.log(`  Transcribing ${videoId} via OpenAI diarization API (model: ${options.model})...`);
+
+  const fileSize = statSync(audioPath).size;
+  let rawSegments;
+
+  if (fileSize <= MAX_FILE_SIZE) {
+    rawSegments = await withRetry(() =>
+      callDiarizedTranscriptionApi(
+        openai,
+        options.model,
+        audioPath,
+        options.knownSpeakerReferences
+      )
+    );
+  } else {
+    const sizeMB = (fileSize / 1024 / 1024).toFixed(1);
+    console.log(`  File is ${sizeMB}MB - splitting into chunks...`);
+
+    const duration = getAudioDuration(audioPath);
+    const chunkDuration = Math.floor((MAX_FILE_SIZE / fileSize) * duration * 0.9);
+    const chunkPaths = splitAudio(audioPath, videoId, chunkDuration);
+
+    console.log(`  Split into ${chunkPaths.length} chunk(s) of ~${chunkDuration}s each`);
+
+    rawSegments = [];
+    try {
+      for (let index = 0; index < chunkPaths.length; index++) {
+        const chunkPath = chunkPaths[index];
+        const offsetSeconds = index * chunkDuration;
+        console.log(`  Transcribing chunk ${index + 1}/${chunkPaths.length}...`);
+
+        const chunkSegments = await withRetry(() =>
+          callDiarizedTranscriptionApi(
+            openai,
+            options.model,
+            chunkPath,
+            options.knownSpeakerReferences,
+            offsetSeconds
+          )
+        );
+
+        rawSegments.push(...chunkSegments);
+      }
+    } finally {
+      cleanupFiles(chunkPaths);
+    }
+  }
+
+  return saveTranscript(videoId, filterNonConversation(rawSegments));
+}
+
+function getTargets(episodes, existingTranscripts, parsedArgs) {
+  const missing = episodes
+    .filter((episode) => !existingTranscripts.has(episode.videoId))
+    .map((episode) => episode.videoId);
+
+  let targets;
+  if (parsedArgs.targets.length === 0) {
+    targets = missing.slice(0, 1);
+  } else if (parsedArgs.targets[0] === "--all") {
+    targets = episodes.map((episode) => episode.videoId);
+  } else if (parsedArgs.targets[0] === "--missing") {
+    targets = missing;
+  } else {
+    targets = parsedArgs.targets;
+  }
+
+  if (parsedArgs.limit !== null && parsedArgs.limit < targets.length) {
+    console.log(`Limiting to ${parsedArgs.limit} episode(s)`);
+    return targets.slice(0, parsedArgs.limit);
+  }
+
+  return targets;
+}
+
+export async function main(rawArgs = process.argv.slice(2)) {
+  const apiKey = process.env.OPENAI_API_KEY;
+  checkRequirements(apiKey);
+
+  const parsedArgs = parseArgs(rawArgs);
+  validateConfiguration(parsedArgs);
+
+  const knownSpeakers = parseKnownSpeakers(parsedArgs.knownSpeakerArgs);
+  const knownSpeakerReferences = buildKnownSpeakerReferences(knownSpeakers);
+  const openai = new OpenAI({
+    apiKey,
+    ...(parsedArgs.baseURL ? { baseURL: parsedArgs.baseURL } : {}),
+  });
+
+  const episodes = getEpisodes();
+  const existingTranscripts = getExistingTranscripts();
+  const targets = getTargets(episodes, existingTranscripts, parsedArgs);
+
+  if (targets.length === 0) {
+    console.log("All episodes already have transcripts!");
+    return;
+  }
+
+  console.log(`Processing ${targets.length} episode(s)...\n`);
+
+  for (const videoId of targets) {
+    const episode = episodes.find((item) => item.videoId === videoId);
+    console.log(`\n[${videoId}] ${episode?.title || "Unknown"}`);
+
+    try {
+      const audioPath = downloadAudio(videoId, {
+        audioFormat: "mp3",
+        browser: parsedArgs.browser,
+        outputExtension: "mp3",
+        ytDlpPath: YT_DLP,
+      });
+
+      await transcribe(audioPath, videoId, openai, {
+        knownSpeakerReferences,
+        model: parsedArgs.model,
+      });
+
+      cleanupFiles([join(TEMP_DIR, `${videoId}.mp3`)]);
+      console.log("  OK Done!");
+    } catch (error) {
+      console.error(`  Error: ${error.message}`);
+    }
+  }
+
+  console.log("\nTranscription complete!");
+}
+
+const isDirectRun =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isDirectRun) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/transcribe-openai-diarize.test.js
+++ b/scripts/transcribe-openai-diarize.test.js
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { parseArgs } from "./transcribe-openai-diarize.js";
+
+describe("parseArgs", () => {
+  it("parses diarization-specific flags alongside the existing selection flags", () => {
+    expect(parseArgs([
+      "--base-url",
+      "https://api.openai.com/v1",
+      "--model",
+      "gpt-4o-transcribe-diarize",
+      "--browser",
+      "chrome",
+      "--known-speaker",
+      "Alice=refs/alice.wav",
+      "--known-speaker",
+      "Bob=refs/bob.wav",
+      "--response-format",
+      "diarized_json",
+      "--missing",
+      "--limit",
+      "3",
+    ])).toEqual({
+      baseURL: "https://api.openai.com/v1",
+      browser: "chrome",
+      knownSpeakerArgs: ["Alice=refs/alice.wav", "Bob=refs/bob.wav"],
+      limit: 3,
+      model: "gpt-4o-transcribe-diarize",
+      responseFormat: "diarized_json",
+      targets: ["--missing"],
+    });
+  });
+});

--- a/scripts/transcribe-openai.js
+++ b/scripts/transcribe-openai.js
@@ -3,38 +3,25 @@
 import { execSync, spawnSync } from "child_process";
 import {
   existsSync,
-  readFileSync,
-  writeFileSync,
-  mkdirSync,
-  unlinkSync,
   createReadStream,
   statSync,
 } from "fs";
-import { join, dirname } from "path";
-import { fileURLToPath } from "url";
+import { join } from "path";
 import OpenAI from "openai";
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const ROOT_DIR = join(__dirname, "..");
-const TRANSCRIPTS_DIR = join(ROOT_DIR, "src/data/transcripts");
-const EPISODES_FILE = join(ROOT_DIR, "src/data/episodes.json");
-const TEMP_DIR = join(ROOT_DIR, ".tmp-audio");
+import {
+  ALLOWED_BROWSERS,
+  TEMP_DIR,
+  cleanupFiles,
+  downloadAudio,
+  filterNonConversation,
+  findExecutable,
+  getEpisodes,
+  getExistingTranscripts,
+  saveTranscript,
+} from "./lib/transcribe-common.js";
 
 // Fallback paths for macOS/Linux when not in PATH
 const YT_DLP_FALLBACK = "/Users/riza/.nix-profile/bin/yt-dlp";
-
-function findExecutable(name, fallback) {
-  try {
-    return execSync(`which ${name}`, { encoding: "utf-8" }).trim();
-  } catch {
-    if (existsSync(fallback)) {
-      return fallback;
-    }
-    throw new Error(
-      `Could not find ${name}. Ensure it's installed or check the path: ${fallback}`
-    );
-  }
-}
 
 const YT_DLP = findExecutable("yt-dlp", YT_DLP_FALLBACK);
 
@@ -100,98 +87,6 @@ function splitAudio(audioPath, videoId, chunkDuration) {
     i++;
   }
   return chunks;
-}
-
-// Patterns for non-conversation segments to filter out (same as transcribe.js)
-const NON_CONVERSATION_PATTERNS = [
-  // Music variations
-  /^\[musik\]$/i,
-  /^\[music\]$/i,
-  /^\[musik intro\]$/i,
-  /^\[suara musik\]$/i,
-  /^\[dialog musik\]$/i,
-  // Sound effects
-  /^\[tinggalow\]$/i,
-  /^\[ting tong\]$/i,
-  /^\[tinggil\]$/i,
-  /^\[telolet\]$/i,
-  /^\[ringtone\]$/i,
-  /^\[drinton\]$/i,
-  /^\[suara panggilan\]$/i,
-  /^\[suara nafas\]$/i,
-  // Laughter
-  /^\[tertawa\]$/i,
-  /^\[ketawa\]$/i,
-  /^\[gelak\]$/i,
-  // Applause
-  /^\[tepuk tangan\]$/i,
-  // Outro/intro messages (metadata, not speech)
-  /^\[sampai jumpa di video selanjutnya\]$/i,
-  /^\[tekan like dan subscribe\]$/i,
-];
-
-function isNonConversation(text) {
-  return NON_CONVERSATION_PATTERNS.some((pattern) => pattern.test(text.trim()));
-}
-
-function filterNonConversation(segments) {
-  const filtered = segments.filter((seg) => !isNonConversation(seg.text));
-  const removedCount = segments.length - filtered.length;
-  if (removedCount > 0) {
-    console.log(`  Filtered out ${removedCount} non-conversation segment(s)`);
-  }
-  return filtered;
-}
-
-function getEpisodes() {
-  return JSON.parse(readFileSync(EPISODES_FILE, "utf-8"));
-}
-
-function getExistingTranscripts() {
-  if (!existsSync(TRANSCRIPTS_DIR)) {
-    mkdirSync(TRANSCRIPTS_DIR, { recursive: true });
-    return new Set();
-  }
-  const files = execSync(`ls "${TRANSCRIPTS_DIR}"`, {
-    encoding: "utf-8",
-  }).trim();
-  if (!files) return new Set();
-  return new Set(files.split("\n").map((f) => f.replace(".json", "")));
-}
-
-function downloadAudio(videoId, browser = "brave") {
-  if (!existsSync(TEMP_DIR)) {
-    mkdirSync(TEMP_DIR, { recursive: true });
-  }
-
-  const outputPath = join(TEMP_DIR, `${videoId}.mp3`);
-
-  if (existsSync(outputPath)) {
-    console.log(`  Audio already exists: ${outputPath}`);
-    return outputPath;
-  }
-
-  console.log(`  Downloading audio for ${videoId}...`);
-
-  const url = `https://www.youtube.com/watch?v=${videoId}`;
-  spawnSync(
-    YT_DLP,
-    [
-      "-x",
-      "--audio-format",
-      "mp3",
-      "--audio-quality",
-      "0",
-      "--cookies-from-browser",
-      browser,
-      "-o",
-      outputPath,
-      url,
-    ],
-    { stdio: "inherit" }
-  );
-
-  return outputPath;
 }
 
 const MAX_RETRIES = 3;
@@ -296,34 +191,17 @@ async function transcribe(audioPath, videoId, openai, model) {
         rawSegments.push(...chunkSegments);
       }
     } finally {
-      for (const chunkPath of chunkPaths) {
-        if (existsSync(chunkPath)) unlinkSync(chunkPath);
-      }
+      cleanupFiles(chunkPaths);
     }
   }
 
   const filteredSegments = filterNonConversation(rawSegments);
 
-  const transcript = {
-    videoId,
-    language: "id",
-    generatedAt: new Date().toISOString(),
-    segments: filteredSegments,
-    fullText: filteredSegments.map((seg) => seg.text).join(" "),
-  };
-
-  const outputPath = join(TRANSCRIPTS_DIR, `${videoId}.json`);
-  writeFileSync(outputPath, JSON.stringify(transcript, null, 2));
-  console.log(`  Saved transcript: ${outputPath}`);
-
-  return transcript;
+  return saveTranscript(videoId, filteredSegments);
 }
 
 function cleanup(videoId) {
-  const file = join(TEMP_DIR, `${videoId}.mp3`);
-  if (existsSync(file)) {
-    unlinkSync(file);
-  }
+  cleanupFiles([join(TEMP_DIR, `${videoId}.mp3`)]);
 }
 
 async function main() {
@@ -376,16 +254,6 @@ async function main() {
   }
 
   // Parse --browser argument
-  const ALLOWED_BROWSERS = [
-    "brave",
-    "chrome",
-    "firefox",
-    "safari",
-    "edge",
-    "chromium",
-    "opera",
-    "vivaldi",
-  ];
   let browser = "brave";
   const browserIndex = args.indexOf("--browser");
   if (browserIndex !== -1) {
@@ -442,7 +310,12 @@ async function main() {
     console.log(`\n[${videoId}] ${episode?.title || "Unknown"}`);
 
     try {
-      const audioPath = downloadAudio(videoId, browser);
+      const audioPath = downloadAudio(videoId, {
+        audioFormat: "mp3",
+        browser,
+        outputExtension: "mp3",
+        ytDlpPath: YT_DLP,
+      });
       await transcribe(audioPath, videoId, openai, model);
       cleanup(videoId);
       console.log(`  ✓ Done!`);

--- a/scripts/transcribe.js
+++ b/scripts/transcribe.js
@@ -1,22 +1,20 @@
 #!/usr/bin/env node
 
 import { execSync, spawnSync } from "child_process";
-import {
-  existsSync,
-  readFileSync,
-  writeFileSync,
-  mkdirSync,
-  unlinkSync,
-} from "fs";
-import { join, dirname } from "path";
-import { fileURLToPath } from "url";
+import { readFileSync } from "fs";
+import { join } from "path";
 import { homedir } from "os";
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const ROOT_DIR = join(__dirname, "..");
-const TRANSCRIPTS_DIR = join(ROOT_DIR, "src/data/transcripts");
-const EPISODES_FILE = join(ROOT_DIR, "src/data/episodes.json");
-const TEMP_DIR = join(ROOT_DIR, ".tmp-audio");
+import {
+  ALLOWED_BROWSERS,
+  TEMP_DIR,
+  cleanupFiles,
+  downloadAudio,
+  filterNonConversation,
+  findExecutable,
+  getEpisodes,
+  getExistingTranscripts,
+  saveTranscript,
+} from "./lib/transcribe-common.js";
 
 const WHISPER_MODEL_DEFAULT = join(homedir(), "Downloads/ggml-medium.bin");
 
@@ -24,113 +22,8 @@ const WHISPER_MODEL_DEFAULT = join(homedir(), "Downloads/ggml-medium.bin");
 const WHISPER_CLI_FALLBACK = "/Users/riza/.nix-profile/bin/whisper-cli";
 const YT_DLP_FALLBACK = "/Users/riza/.nix-profile/bin/yt-dlp";
 
-function findExecutable(name, fallback) {
-  try {
-    return execSync(`which ${name}`, { encoding: "utf-8" }).trim();
-  } catch {
-    if (existsSync(fallback)) {
-      return fallback;
-    }
-    throw new Error(
-      `Could not find ${name}. Ensure it's installed or check the path: ${fallback}`
-    );
-  }
-}
-
 const WHISPER_CLI = findExecutable("whisper-cli", WHISPER_CLI_FALLBACK);
 const YT_DLP = findExecutable("yt-dlp", YT_DLP_FALLBACK);
-
-// Patterns for non-conversation segments to filter out
-const NON_CONVERSATION_PATTERNS = [
-  // Music variations
-  /^\[musik\]$/i,
-  /^\[music\]$/i,
-  /^\[musik intro\]$/i,
-  /^\[suara musik\]$/i,
-  /^\[dialog musik\]$/i,
-  // Sound effects
-  /^\[tinggalow\]$/i,
-  /^\[ting tong\]$/i,
-  /^\[tinggil\]$/i,
-  /^\[telolet\]$/i,
-  /^\[ringtone\]$/i,
-  /^\[drinton\]$/i,
-  /^\[suara panggilan\]$/i,
-  /^\[suara nafas\]$/i,
-  // Laughter
-  /^\[tertawa\]$/i,
-  /^\[ketawa\]$/i,
-  /^\[gelak\]$/i,
-  // Applause
-  /^\[tepuk tangan\]$/i,
-  // Outro/intro messages (metadata, not speech)
-  /^\[sampai jumpa di video selanjutnya\]$/i,
-  /^\[tekan like dan subscribe\]$/i,
-];
-
-function isNonConversation(text) {
-  return NON_CONVERSATION_PATTERNS.some((pattern) => pattern.test(text.trim()));
-}
-
-function filterNonConversation(segments) {
-  const filtered = segments.filter((seg) => !isNonConversation(seg.text));
-  const removedCount = segments.length - filtered.length;
-  if (removedCount > 0) {
-    console.log(`  Filtered out ${removedCount} non-conversation segment(s)`);
-  }
-  return filtered;
-}
-
-function getEpisodes() {
-  return JSON.parse(readFileSync(EPISODES_FILE, "utf-8"));
-}
-
-function getExistingTranscripts() {
-  if (!existsSync(TRANSCRIPTS_DIR)) {
-    mkdirSync(TRANSCRIPTS_DIR, { recursive: true });
-    return new Set();
-  }
-  const files = execSync(`ls "${TRANSCRIPTS_DIR}"`, {
-    encoding: "utf-8",
-  }).trim();
-  if (!files) return new Set();
-  return new Set(files.split("\n").map((f) => f.replace(".json", "")));
-}
-
-function downloadAudio(videoId, browser = "brave") {
-  if (!existsSync(TEMP_DIR)) {
-    mkdirSync(TEMP_DIR, { recursive: true });
-  }
-
-  const outputPath = join(TEMP_DIR, `${videoId}.wav`);
-
-  if (existsSync(outputPath)) {
-    console.log(`  Audio already exists: ${outputPath}`);
-    return outputPath;
-  }
-
-  console.log(`  Downloading audio for ${videoId}...`);
-
-  const url = `https://www.youtube.com/watch?v=${videoId}`;
-  spawnSync(
-    YT_DLP,
-    [
-      "-x",
-      "--audio-format",
-      "wav",
-      "--audio-quality",
-      "0",
-      "--cookies-from-browser",
-      browser,
-      "-o",
-      outputPath,
-      url,
-    ],
-    { stdio: "inherit" }
-  );
-
-  return outputPath;
-}
 
 function transcribe(audioPath, videoId, model, suppressNst = false) {
   console.log(`  Transcribing ${videoId}${suppressNst ? " (with -sns flag)" : ""}...`);
@@ -158,32 +51,14 @@ function transcribe(audioPath, videoId, model, suppressNst = false) {
   // Only filter if not using -sns (suppression should handle it during transcription)
   const filteredSegments = suppressNst ? rawSegments : filterNonConversation(rawSegments);
 
-  const transcript = {
-    videoId,
-    language: "id",
-    generatedAt: new Date().toISOString(),
-    segments: filteredSegments,
-    fullText: filteredSegments.map((seg) => seg.text).join(" "),
-  };
-
-  const outputPath = join(TRANSCRIPTS_DIR, `${videoId}.json`);
-  writeFileSync(outputPath, JSON.stringify(transcript, null, 2));
-  console.log(`  Saved transcript: ${outputPath}`);
-
-  return transcript;
+  return saveTranscript(videoId, filteredSegments);
 }
 
 function cleanup(videoId) {
-  const files = [
+  cleanupFiles([
     join(TEMP_DIR, `${videoId}.wav`),
     join(TEMP_DIR, `${videoId}.json`),
-  ];
-
-  for (const file of files) {
-    if (existsSync(file)) {
-      unlinkSync(file);
-    }
-  }
+  ]);
 }
 
 async function main() {
@@ -220,16 +95,6 @@ async function main() {
   }
 
   // Parse --browser argument
-  const ALLOWED_BROWSERS = [
-    "brave",
-    "chrome",
-    "firefox",
-    "safari",
-    "edge",
-    "chromium",
-    "opera",
-    "vivaldi",
-  ];
   let browser = "brave";
   const browserIndex = args.indexOf("--browser");
   if (browserIndex !== -1) {
@@ -295,7 +160,12 @@ async function main() {
     console.log(`\n[${videoId}] ${episode?.title || "Unknown"}`);
 
     try {
-      const audioPath = downloadAudio(videoId, browser);
+      const audioPath = downloadAudio(videoId, {
+        audioFormat: "wav",
+        browser,
+        outputExtension: "wav",
+        ytDlpPath: YT_DLP,
+      });
       transcribe(audioPath, videoId, whisperModel, suppressNst);
       cleanup(videoId);
       console.log(`  ✓ Done!`);


### PR DESCRIPTION
## Summary
- Refactor transcription scripts to support OpenAI's speaker diarization
- Extract common logic into shared modules (`transcribe-common.js`)
- Add new `transcribe-openai-diarize` command for speaker-separated transcripts
- Add tests for new diarization functionality

## WIP
This is a work-in-progress PR for review.

## Test plan
- [ ] Test common module extraction works for existing transcribe scripts
- [ ] Test new diarize command produces speaker-separated transcripts
- [ ] Run unit tests for new modules